### PR TITLE
[components] Fix broken element_indexes_with_fonts method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Documentation is now hosted [here](https://py-pdf-parser.readthedocs.io/en/latest/).
-- Font filtering now caches the elements by font. ([#73](https://github.com/jstockwin/py-pdf-parser/pull/73))
+- Font filtering now caches the elements by font. ([#73](https://github.com/jstockwin/py-pdf-parser/pull/73)) (updated in [#78](https://github.com/jstockwin/py-pdf-parser/pull/78))
 
 ### Changed
 - This product is now complete enough for the needs of Optimor Ltd, however `jstockwin` is going to continue development as a personal project. The repository has been moved from `optimor/py-pdf-parser` to `jstockwin/py-pdf-parser`.

--- a/py_pdf_parser/components.py
+++ b/py_pdf_parser/components.py
@@ -473,4 +473,12 @@ class PDFDocument:
                 self._element_indexes_by_font[element.font].add(element._index)
 
         # Returns elements based on the caching of fonts to elements indexes.
-        return set(chain.from_iterable(self._element_indexes_by_font.values()))
+        return set(
+            chain.from_iterable(
+                [
+                    indexes
+                    for font, indexes in self._element_indexes_by_font.items()
+                    if font in fonts
+                ]
+            )
+        )

--- a/py_pdf_parser/tests/test_filtering.py
+++ b/py_pdf_parser/tests/test_filtering.py
@@ -161,6 +161,13 @@ class TestFiltering(BaseTestCase):
         self.assertEqual(doc._element_indexes_by_font, {"foo,2": set([0])})
         self.assert_original_element_in(elem1, doc.elements.filter_by_font("foo,2"))
 
+        # Check we can still filter for another font which is not in cache
+        self.assertEqual(len(doc.elements.filter_by_font("bar,3")), 1)
+        self.assertEqual(
+            doc._element_indexes_by_font, {"foo,2": set([0]), "bar,3": set([1])}
+        )
+        self.assert_original_element_in(elem2, doc.elements.filter_by_font("bar,3"))
+
         doc = create_pdf_document([elem1, elem2], font_mapping={"foo,2": "font_a"})
         self.assertEqual(len(doc.elements.filter_by_font("hello,1")), 0)
         self.assertEqual(len(doc.elements.filter_by_font("foo,2")), 0)
@@ -207,6 +214,19 @@ class TestFiltering(BaseTestCase):
         )
         self.assert_original_element_in(
             elem2, doc.elements.filter_by_fonts("font_a", "font_b")
+        )
+
+        # Check we can still filter for another font which is not in cache
+        self.assertEqual(len(doc.elements.filter_by_fonts("font_b", "font_c")), 2)
+        self.assert_original_element_in(
+            elem2, doc.elements.filter_by_fonts("font_b", "font_c")
+        )
+        self.assert_original_element_in(
+            elem3, doc.elements.filter_by_fonts("font_b", "font_c")
+        )
+        self.assertEqual(
+            doc._element_indexes_by_font,
+            {"font_a": set([0]), "font_b": set([1]), "font_c": set([2])},
         )
 
     def test_filter_by_page(self):


### PR DESCRIPTION
Fixed a bug where filtering by font was broken.

Closes #77

- [x] I have provided a good description of the change above
- [x] I have added any necessary tests
- [x] I have added all necessary type hints
- [x] I have checked my linting (`docker-compose run --rm lint`)
- [x] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
