### PR TITLE
[meta] Run github actions steps in parallel

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,9 +13,24 @@ jobs:
           image_name: jstockwin/py-pdf-parser-test
           image_tag: test
           dockerfile: dockerfiles/Dockerfile_tests
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
       - name: Run linting
         run: docker run --rm jstockwin/py-pdf-parser-test:test .github/scripts/lint.sh
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
       - name: Run test
         run: docker run --rm jstockwin/py-pdf-parser-test:test .github/scripts/test.sh
+  docs:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
       - name: Check docs build correctly
         run: docker run --rm jstockwin/py-pdf-parser-test:test .github/scripts/docs.sh


### PR DESCRIPTION
**Description**

Runs tests, linting and docs in parallel.

**Linked issues**

None

**Testing**

N/A

**Checklist**

- [x] I have provided a good description of the change above
- [x] I have added any necessary tests
- [x] I have added all necessary type hints
- [x] I have checked my linting (`docker-compose run --rm lint`)
- [x] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
