### PR TITLE
[meta] Add github action to publish all releases to pypi and dockerhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Publish new version
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Get the tag
+      id: tagName
+      run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+    - name: Publish to docker hub
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: jstockwin/py-pdf-parser
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: dockerfiles/Dockerfile
+        tags: ${{ steps.tagName.outputs.tag }}
+    - name: Install build packages
+      run: pip3 install twine==3.1.1 wheel==0.34.2
+    - name: Build package
+      run: python3 setup.py sdist bdist_wheel
+    - name: Check built package
+      run: twine check dist/*
+    - name: Package package to PyPI
+      run: twine upload dist/*


### PR DESCRIPTION
**Description**

This github action will run whenever we publish a new release. It will push the dockerfile to dockerhub, and build + check the package and push to PyPI.

Credentials are taken from secrets, which I've added.

**Linked issues**

Closes #79
