### PR TITLE
Disable advanced layout analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Advanced layout analysis is now disabled by default. ([#88](https://github.com/jstockwin/py-pdf-parser/pull/88))
+
 ## [0.3.0] - 2020-05-14
 ### Added
 - Published to PyPI as py-pdf-parser.

--- a/py_pdf_parser/loaders.py
+++ b/py_pdf_parser/loaders.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from pdfminer.layout import LTComponent
 
 logger = logging.getLogger("PDFParser")
+DEFAULT_LA_PARAMS: Dict = {"boxes_flow": None}
 
 
 class Page(NamedTuple):
@@ -68,6 +69,7 @@ def load(
     """
     if la_params is None:
         la_params = {}
+    la_params = {**DEFAULT_LA_PARAMS, **la_params}
 
     pages: Dict[int, Page] = {}
     for page in extract_pages(pdf_file, laparams=LAParams(**la_params)):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email="jstockwin@gmail.com",
     include_package_data=True,
     install_requires=[
-        "pdfminer.six==20200402",
+        "pdfminer.six==20200517",
         "docopt==0.6.2",
         "wand==0.4.4",
         "PyYAML==5.1",


### PR DESCRIPTION
**Description**

Advanced layout analysis is not needed since we order text boxes ourselves, so we can disable it by default and hence improve the performance of the analysis.

**Linked issues**

Closes https://github.com/jstockwin/py-pdf-parser/issues/50

**Checklist**

- [x] I have provided a good description of the change above
- [x] I have added any necessary tests
- [x] I have added all necessary type hints
- [x] I have checked my linting (`docker-compose run --rm lint`)
- [x] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
