### PR TITLE
[tables] Add flag to remove duplicate header rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Added
 - Added flag to `extract_simple_table` and `extract_table` functions to remove duplicate header rows. ([#89](https://github.com/jstockwin/py-pdf-parser/pull/89))
+### Changed
 - Advanced layout analysis is now disabled by default. ([#88](https://github.com/jstockwin/py-pdf-parser/pull/88))
 
 ## [0.3.0] - 2020-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Added flag to `extract_simple_table` and `extract_table` functions to remove duplicate header rows. ([#89](https://github.com/jstockwin/py-pdf-parser/pull/89))
 - Advanced layout analysis is now disabled by default. ([#88](https://github.com/jstockwin/py-pdf-parser/pull/88))
 
 ## [0.3.0] - 2020-05-14

--- a/py_pdf_parser/tables.py
+++ b/py_pdf_parser/tables.py
@@ -456,32 +456,44 @@ def _remove_duplicate_header_rows(table: List[List[Any]]) -> List[List[Any]]:
 
     Returns:
         List[List[Any]]: The table without the duplicate header rows.
-
     """
     if len(table) <= 1:
         return table
-
-    def elements_equal(elem_1: Optional["PDFElement"], elem_2: Optional["PDFElement"]):
-        if elem_1 is None and elem_2 is None:
-            return True
-
-        if (elem_1 is None or elem_2 is None) or (
-            elem_2 is None and elem_1 is not None
-        ):
-            return False
-
-        if elem_1.text() != elem_2.text() or elem_1.font != elem_2.font:
-            return False
-
-        return True
 
     header = table[0]
     rows_without_duplicate_header = [
         row
         for row in table[1:]
         if any(
-            not elements_equal(element, header[index])
+            not _are_elements_equal(element, header[index])
             for index, element in enumerate(row)
         )
     ]
     return [header] + rows_without_duplicate_header
+
+
+def _are_elements_equal(
+    elem_1: Optional["PDFElement"], elem_2: Optional["PDFElement"]
+) -> bool:
+    """
+    Checks if two elements are equal.
+    Two elements are considered equal if they are both None or they have the same text
+    and font.
+
+    Args:
+        elem_1 (PDFElement, optional): The first element to compare.
+        elem_2 (PDFElement, optional): The second element to compare.
+
+    Returns:
+        bool: True if elements are equal, False otherwise.
+    """
+    if elem_1 is None and elem_2 is None:
+        return True
+
+    if elem_1 is None or elem_2 is None:
+        return False
+
+    if elem_1.text() != elem_2.text() or elem_1.font != elem_2.font:
+        return False
+
+    return True

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -184,6 +184,92 @@ class TestTables(BaseTestCase):
             [[elem_1, elem_2], [elem_3, elem_4]], result
         )
 
+    def test_extract_simple_table_removing_duplicate_header_rows(self):
+        #    header_elem_1    header_elem_2
+        header_elem_1 = FakePDFMinerTextElement(
+            text="header 1",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(0, 5, 21, 25),
+        )
+        header_elem_2 = FakePDFMinerTextElement(
+            text="header 2",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(6, 10, 21, 25),
+        )
+        document = create_pdf_document(elements=[header_elem_1, header_elem_2])
+        elem_list = document.elements
+
+        result = extract_simple_table(elem_list, remove_duplicate_header_rows=True)
+        # Extraction here should just return the whole table as it is not possible to
+        # have duplicates of a single lined table.
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0]), 2)
+        self.assert_original_element_list_list_equal(
+            [[header_elem_1, header_elem_2]], result
+        )
+
+        #    header_elem_1    header_elem_2
+        #       elem_1           elem_2
+        #    header_elem_3    header_elem_4
+        #       elem_3           elem_4
+        #    header_elem_5    header_elem_6
+        #
+        elem_1 = FakePDFMinerTextElement(bounding_box=BoundingBox(0, 5, 16, 20))
+        elem_2 = FakePDFMinerTextElement(bounding_box=BoundingBox(6, 10, 16, 20))
+        header_elem_3 = FakePDFMinerTextElement(
+            text="header 1",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(0, 5, 11, 15),
+        )
+        header_elem_4 = FakePDFMinerTextElement(
+            text="header 2",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(6, 10, 11, 15),
+        )
+        elem_3 = FakePDFMinerTextElement(bounding_box=BoundingBox(0, 5, 6, 10))
+        elem_4 = FakePDFMinerTextElement(bounding_box=BoundingBox(6, 10, 6, 10))
+        header_elem_5 = FakePDFMinerTextElement(
+            text="header 1",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(0, 5, 0, 5),
+        )
+        header_elem_6 = FakePDFMinerTextElement(
+            text="header 2",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(6, 10, 0, 5),
+        )
+
+        document = create_pdf_document(
+            elements=[
+                header_elem_1,
+                header_elem_2,
+                elem_1,
+                elem_2,
+                header_elem_3,
+                header_elem_4,
+                elem_3,
+                elem_4,
+                header_elem_5,
+                header_elem_6,
+            ]
+        )
+        elem_list = document.elements
+
+        result = extract_simple_table(elem_list, remove_duplicate_header_rows=True)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(len(result[0]), 2)
+        self.assertEqual(len(result[1]), 2)
+        self.assertEqual(len(result[2]), 2)
+        self.assert_original_element_list_list_equal(
+            [[header_elem_1, header_elem_2], [elem_1, elem_2], [elem_3, elem_4]], result
+        )
+
     def test_extract_table(self):
         # Checks that simple 2*2 table is correctly extracted
         #
@@ -309,6 +395,100 @@ class TestTables(BaseTestCase):
         self.assertEqual(len(result[1]), 2)
         self.assert_original_element_list_list_equal(
             [[elem_1, elem_2], [elem_3, elem_4]], result
+        )
+
+    def test_extract_table_removing_duplicate_header_rows(self):
+        #    header_elem_1    header_elem_2
+        header_elem_1 = FakePDFMinerTextElement(
+            text="header 1",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(0, 5, 21, 25),
+        )
+        header_elem_2 = FakePDFMinerTextElement(
+            text="header 2",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(11, 15, 21, 25),
+        )
+        document = create_pdf_document(elements=[header_elem_1, header_elem_2])
+        elem_list = document.elements
+
+        result = extract_simple_table(elem_list, remove_duplicate_header_rows=True)
+        # Extraction here should just return the whole table as it is not possible to
+        # have duplicates of a single lined table.
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0]), 2)
+        self.assert_original_element_list_list_equal(
+            [[header_elem_1, header_elem_2]], result
+        )
+
+        #    header_elem_1                     header_elem_2
+        #       elem_1           elem_2
+        #    header_elem_3                     header_elem_4
+        #       elem_3                         elem_4
+        #    header_elem_5    header_elem_6
+        #
+        elem_1 = FakePDFMinerTextElement(bounding_box=BoundingBox(0, 5, 16, 20))
+        elem_2 = FakePDFMinerTextElement(bounding_box=BoundingBox(6, 10, 16, 20))
+        header_elem_3 = FakePDFMinerTextElement(
+            text="header 1",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(0, 5, 11, 15),
+        )
+        header_elem_4 = FakePDFMinerTextElement(
+            text="header 2",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(11, 15, 11, 15),
+        )
+        elem_3 = FakePDFMinerTextElement(bounding_box=BoundingBox(0, 5, 6, 10))
+        elem_4 = FakePDFMinerTextElement(bounding_box=BoundingBox(11, 15, 6, 10))
+        header_elem_5 = FakePDFMinerTextElement(
+            text="header 1",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(0, 5, 0, 5),
+        )
+        header_elem_6 = FakePDFMinerTextElement(
+            text="header 2",
+            font_name="header font",
+            font_size=10,
+            bounding_box=BoundingBox(6, 10, 0, 5),
+        )
+
+        document = create_pdf_document(
+            elements=[
+                header_elem_1,
+                header_elem_2,
+                elem_1,
+                elem_2,
+                header_elem_3,
+                header_elem_4,
+                elem_3,
+                elem_4,
+                header_elem_5,
+                header_elem_6,
+            ]
+        )
+        elem_list = document.elements
+
+        result = extract_table(elem_list, remove_duplicate_header_rows=True)
+        # The last row will not be removed as the gaps do not match the header row
+        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result[0]), 3)
+        self.assertEqual(len(result[1]), 3)
+        self.assertEqual(len(result[2]), 3)
+        self.assertEqual(len(result[3]), 3)
+        self.assert_original_element_list_list_equal(
+            [
+                [header_elem_1, None, header_elem_2],
+                [elem_1, elem_2, None],
+                [elem_3, None, elem_4],
+                [header_elem_5, header_elem_6, None],
+            ],
+            result,
         )
 
     def test_extract_text_from_simple_table(self):


### PR DESCRIPTION
**Description**

This will add a flag to the table extraction functions to enable the removal of rows which are duplicats of the header row.

**Linked issues**

Closes https://github.com/jstockwin/py-pdf-parser/issues/76

**Testing**

Tests have been added to the table extraction tests to make sure the duplicate header rows are removed.

**Checklist**

- [X] I have provided a good description of the change above
- [X] I have added any necessary tests
- [X] I have added all necessary type hints
- [X] I have checked my linting (`docker-compose run --rm lint`)
- [X] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
