### PR TITLE
Section repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added `__len__` and `__repr__` functions to the Section class. ([#90](https://github.com/jstockwin/py-pdf-parser/pull/90))
 - Added flag to `extract_simple_table` and `extract_table` functions to remove duplicate header rows. ([#89](https://github.com/jstockwin/py-pdf-parser/pull/89))
 ### Changed
 - Advanced layout analysis is now disabled by default. ([#88](https://github.com/jstockwin/py-pdf-parser/pull/88))

--- a/py_pdf_parser/sectioning.py
+++ b/py_pdf_parser/sectioning.py
@@ -82,6 +82,12 @@ class Section:
         """
         return len(self.elements)
 
+    def __repr__(self):
+        return (
+            f"<Section name: '{self.name}', unique_name: '{self.unique_name}', "
+            f"number of elements: {len(self)}>"
+        )
+
 
 class Sectioning:
     """

--- a/py_pdf_parser/sectioning.py
+++ b/py_pdf_parser/sectioning.py
@@ -76,6 +76,12 @@ class Section:
             ]
         )
 
+    def __len__(self):
+        """
+        Returns the number of elements in the section.
+        """
+        return len(self.elements)
+
 
 class Sectioning:
     """

--- a/tests/test_sectioning.py
+++ b/tests/test_sectioning.py
@@ -80,6 +80,40 @@ class TestSection(BaseTestCase):
         pdf_elem_2.ignore()
         self.assertEqual(len(section), 2)
 
+    def test_repr(self):
+        elem_1 = FakePDFMinerTextElement()
+        elem_2 = FakePDFMinerTextElement()
+        document = create_pdf_document([elem_1, elem_2])
+
+        pdf_elem_1 = self.extract_element_from_list(elem_1, document._element_list)
+        pdf_elem_2 = self.extract_element_from_list(elem_2, document._element_list)
+
+        section = create_section(
+            document,
+            name="fake_section",
+            unique_name="fake_section_0",
+            start_element=pdf_elem_1,
+            end_element=pdf_elem_2,
+        )
+
+        self.assertEqual(
+            repr(section),
+            (
+                "<Section name: 'fake_section', unique_name: 'fake_section_0', "
+                "number of elements: 2>"
+            ),
+        )
+
+        # Ignoring an element should affect the number of elements of the section.
+        pdf_elem_2.ignore()
+        self.assertEqual(
+            repr(section),
+            (
+                "<Section name: 'fake_section', unique_name: 'fake_section_0', "
+                "number of elements: 1>"
+            ),
+        )
+
 
 class TestSectioning(BaseTestCase):
     def test_create_section(self):

--- a/tests/test_sectioning.py
+++ b/tests/test_sectioning.py
@@ -58,6 +58,28 @@ class TestSection(BaseTestCase):
         with self.assertRaises(InvalidSectionError):
             create_section(document, start_element=pdf_elem_2, end_element=pdf_elem_1)
 
+    def test_len(self):
+        elem_1 = FakePDFMinerTextElement()
+        elem_2 = FakePDFMinerTextElement()
+        elem_3 = FakePDFMinerTextElement()
+        document = create_pdf_document([elem_1, elem_2, elem_3])
+
+        pdf_elem_1 = self.extract_element_from_list(elem_1, document._element_list)
+        pdf_elem_2 = self.extract_element_from_list(elem_2, document._element_list)
+        pdf_elem_3 = self.extract_element_from_list(elem_3, document._element_list)
+
+        section = create_section(
+            document,
+            name="fake_section",
+            start_element=pdf_elem_1,
+            end_element=pdf_elem_3,
+        )
+        self.assertEqual(len(section), 3)
+
+        # Ignoring an element should affect the length of the section.
+        pdf_elem_2.ignore()
+        self.assertEqual(len(section), 2)
+
 
 class TestSectioning(BaseTestCase):
     def test_create_section(self):


### PR DESCRIPTION
**Description**

This adds a `__len__` and `__repr__` functions to the `Section` class.

**Linked issues**

Closes https://github.com/jstockwin/py-pdf-parser/issues/63

**Testing**

Tests were added to the section tests that make sure that calling `len()` and `repr()` on a section will return the expected results.

**Checklist**

- [X] I have provided a good description of the change above
- [X] I have added any necessary tests
- [X] I have added all necessary type hints
- [X] I have checked my linting (`docker-compose run --rm lint`)
- [X] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
