### PR TITLE
[filtering] Cap tolerance at half the width/height of the element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - When the layout parameter all_texts is True, the text inside figures is now also returned as elements in the document. ([#99](https://github.com/jstockwin/py-pdf-parser/pull/99))
 
+### Fixed
+- Passing a tolerance less than the width/height of an element no longer causes an error. The tolerance is now capped at half the width/height of the element. ([#103](https://github.com/jstockwin/py-pdf-parser/pull/103))
+
 ## [0.4.0] - 2020-06-22
 ### Added
 - Added `__len__` and `__repr__` functions to the Section class. ([#90](https://github.com/jstockwin/py-pdf-parser/pull/90))

--- a/py_pdf_parser/filtering.py
+++ b/py_pdf_parser/filtering.py
@@ -364,13 +364,15 @@ class ElementList(Iterable):
             inclusive (bool, optional): Whether the include `element` in the returned
                 results. Default: False.
             tolerance (int, optional): To be counted as to the right, the elements must
-                overlap by at least `tolerance` on the Y axis. Default 0.
+                overlap by at least `tolerance` on the Y axis. Tolerance is capped at
+                half the height of the element. Default 0.
 
         Returns:
             ElementList: The filtered list.
         """
         page_number = element.page_number
         page = self.document.get_page(page_number)
+        tolerance = min(element.bounding_box.height / 2, tolerance)
         bounding_box = BoundingBox(
             element.bounding_box.x1,
             page.width,
@@ -407,13 +409,15 @@ class ElementList(Iterable):
             inclusive (bool, optional): Whether the include `element` in the returned
                 results. Default: False.
             tolerance (int, optional): To be counted as to the left, the elements must
-                overlap by at least `tolerance` on the Y axis. Default 0.
+                overlap by at least `tolerance` on the Y axis. Tolerance is capped at
+                half the height of the element. Default 0.
 
 
         Returns:
             ElementList: The filtered list.
         """
         page_number = element.page_number
+        tolerance = min(element.bounding_box.height / 2, tolerance)
         bounding_box = BoundingBox(
             0,
             element.bounding_box.x0,
@@ -458,12 +462,14 @@ class ElementList(Iterable):
             all_pages (bool, optional): Whether to included pages other than the page
                 which the element is on.
             tolerance (int, optional): To be counted as below, the elements must
-                overlap by at least `tolerance` on the X axis. Default 0.
+                overlap by at least `tolerance` on the X axis. Tolerance is capped at
+                half the width of the element. Default 0.
 
         Returns:
             ElementList: The filtered list.
         """
         page_number = element.page_number
+        tolerance = min(element.bounding_box.width / 2, tolerance)
         bounding_box = BoundingBox(
             element.bounding_box.x0 + tolerance,
             element.bounding_box.x1 - tolerance,
@@ -523,13 +529,15 @@ class ElementList(Iterable):
             all_pages (bool, optional): Whether to included pages other than the page
                 which the element is on.
             tolerance (int, optional): To be counted as above, the elements must
-                overlap by at least `tolerance` on the X axis. Default 0.
+                overlap by at least `tolerance` on the X axis. Tolerance is capped at
+                half the width of the element. Default 0.
 
         Returns:
             ElementList: The filtered list.
         """
         page_number = element.page_number
         page = self.document.get_page(page_number)
+        tolerance = min(element.bounding_box.width / 2, tolerance)
         bounding_box = BoundingBox(
             element.bounding_box.x0 + tolerance,
             element.bounding_box.x1 - tolerance,
@@ -586,13 +594,15 @@ class ElementList(Iterable):
             all_pages (bool, optional): Whether to included pages other than the page
                 which the element is on.
             tolerance (int, optional): To be counted as in line with, the elements must
-                overlap by at least `tolerance` on the X axis. Default 0.
+                overlap by at least `tolerance` on the X axis. Tolerance is capped at
+                half the width of the element. Default 0.
 
         Returns:
             ElementList: The filtered list.
         """
         page_number = element.page_number
         page = self.document.get_page(page_number)
+        tolerance = min(element.bounding_box.width / 2, tolerance)
         bounding_box = BoundingBox(
             element.bounding_box.x0 + tolerance,
             element.bounding_box.x1 - tolerance,
@@ -642,13 +652,15 @@ class ElementList(Iterable):
             inclusive (bool, optional): Whether the include `element` in the returned
                 results. Default: False.
             tolerance (int, optional): To be counted as in line with, the elements must
-                overlap by at least `tolerance` on the Y axis. Default 0.
+                overlap by at least `tolerance` on the Y axis. Tolerance is capped at
+                half the width of the element. Default 0.
 
         Returns:
             ElementList: The filtered list.
         """
         page_number = element.page_number
         page = self.document.get_page(page_number)
+        tolerance = min(element.bounding_box.height / 2, tolerance)
         bounding_box = BoundingBox(
             0,
             page.width,

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -415,6 +415,22 @@ class TestFiltering(BaseTestCase):
             any_order=True,
         )
 
+        # Test tolerance gets capped at half the height of the element
+        expected_bbox = BoundingBox(51, 100, 50.5, 50.5)
+
+        partially_within_mock.reset_mock()
+        result = elem_list.to_the_right_of(pdf_elem1, tolerance=1)
+
+        partially_within_mock.assert_has_calls(
+            [
+                call(pdf_elem1, expected_bbox),
+                call(pdf_elem2, expected_bbox),
+                call(pdf_elem3, expected_bbox),
+                call(pdf_elem4, expected_bbox),
+            ],
+            any_order=True,
+        )
+
     @patch.object(PDFElement, "partially_within", autospec=True)
     def test_to_the_left_of(self, partially_within_mock):
         partially_within_mock.side_effect = (
@@ -483,6 +499,22 @@ class TestFiltering(BaseTestCase):
 
         partially_within_mock.reset_mock()
         result = elem_list.to_the_left_of(pdf_elem1, tolerance=0.1)
+
+        partially_within_mock.assert_has_calls(
+            [
+                call(pdf_elem1, expected_bbox),
+                call(pdf_elem2, expected_bbox),
+                call(pdf_elem3, expected_bbox),
+                call(pdf_elem4, expected_bbox),
+            ],
+            any_order=True,
+        )
+
+        # Test tolerance gets capped at half the height of the element
+        expected_bbox = BoundingBox(0, 50, 50.5, 50.5)
+
+        partially_within_mock.reset_mock()
+        result = elem_list.to_the_left_of(pdf_elem1, tolerance=1)
 
         partially_within_mock.assert_has_calls(
             [
@@ -599,6 +631,22 @@ class TestFiltering(BaseTestCase):
             any_order=True,
         )
 
+        # Test tolerance gets capped at half the width of the element
+        expected_bbox = BoundingBox(50.5, 50.5, 0, 50)
+
+        partially_within_mock.reset_mock()
+        result = elem_list.below(pdf_elem3, tolerance=1)
+
+        partially_within_mock.assert_has_calls(
+            [
+                call(pdf_elem3, expected_bbox),
+                call(pdf_elem4, expected_bbox),
+                call(pdf_elem5, expected_bbox),
+                call(pdf_elem6, expected_bbox),
+            ],
+            any_order=True,
+        )
+
     @patch.object(PDFElement, "partially_within", autospec=True)
     def test_above(self, partially_within_mock):
         partially_within_mock.side_effect = (
@@ -693,6 +741,22 @@ class TestFiltering(BaseTestCase):
 
         partially_within_mock.reset_mock()
         result = elem_list.above(pdf_elem3, tolerance=0.1)
+
+        partially_within_mock.assert_has_calls(
+            [
+                call(pdf_elem3, expected_bbox),
+                call(pdf_elem4, expected_bbox),
+                call(pdf_elem5, expected_bbox),
+                call(pdf_elem6, expected_bbox),
+            ],
+            any_order=True,
+        )
+
+        # Test tolerance gets capped at half the width of the element
+        expected_bbox = BoundingBox(50.5, 50.5, 51, 100)
+
+        partially_within_mock.reset_mock()
+        result = elem_list.above(pdf_elem3, tolerance=1)
 
         partially_within_mock.assert_has_calls(
             [
@@ -814,6 +878,22 @@ class TestFiltering(BaseTestCase):
             any_order=True,
         )
 
+        # Test tolerance gets capped at half the width of the element
+        expected_bbox = BoundingBox(50.5, 50.5, 0, 100)
+
+        partially_within_mock.reset_mock()
+        result = elem_list.vertically_in_line_with(pdf_elem3, tolerance=1)
+
+        partially_within_mock.assert_has_calls(
+            [
+                call(pdf_elem3, expected_bbox),
+                call(pdf_elem4, expected_bbox),
+                call(pdf_elem5, expected_bbox),
+                call(pdf_elem6, expected_bbox),
+            ],
+            any_order=True,
+        )
+
     @patch.object(PDFElement, "partially_within", autospec=True)
     def test_horizontally_in_line_with(self, partially_within_mock):
         partially_within_mock.side_effect = (
@@ -882,6 +962,22 @@ class TestFiltering(BaseTestCase):
 
         partially_within_mock.reset_mock()
         result = elem_list.horizontally_in_line_with(pdf_elem1, tolerance=0.1)
+
+        partially_within_mock.assert_has_calls(
+            [
+                call(pdf_elem1, expected_bbox),
+                call(pdf_elem2, expected_bbox),
+                call(pdf_elem3, expected_bbox),
+                call(pdf_elem4, expected_bbox),
+            ],
+            any_order=True,
+        )
+
+        # Test tolerance gets capped at half the height of the element
+        expected_bbox = BoundingBox(0, 100, 50.5, 50.5)
+
+        partially_within_mock.reset_mock()
+        result = elem_list.horizontally_in_line_with(pdf_elem1, tolerance=1)
 
         partially_within_mock.assert_has_calls(
             [


### PR DESCRIPTION
**Description**

Caps the tolerance at half the width/height of the element, thus avoiding an invalid bounding box error.

**Linked issues**

Closes #102

**Testing**

CI Tests have been added

**Checklist**

- [x] I have provided a good description of the change above
- [x] I have added any necessary tests
- [x] I have added all necessary type hints
- [x] I have checked my linting (`docker-compose run --rm lint`)
- [x] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
