### PR TITLE
[meta] Enable dependabot package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  # Maintain dependenceis from GitHub Actions
+  # Maintain dependencies from GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies from pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependenceis from GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Enabled dependabot which should help to keep packages up to date ([#124](https://github.com/jstockwin/py-pdf-parser/pull/124))
+
 ### Fixed
 - Fixed a typo in simple memo example in the documentation. ([#121](https://github.com/jstockwin/py-pdf-parser/pull/121))
 


### PR DESCRIPTION
**Description**

Adds dependabot, to keep our packages up to date.

**Linked issues**

https://github.com/jstockwin/py-pdf-parser/issues/123 was caused by an out of date package, and this should solve that issue generally.

**Testing**

N/A

**Checklist**

- [X] I have provided a good description of the change above
- [X] I have added any necessary tests
- [X] I have added all necessary type hints
- [X] I have checked my linting (`docker-compose run --rm lint`)
- [X] I have added/updated all necessary documentation
- [X] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
