### PR TITLE
[loaders] Only accept LTTextBoxes from pdfminer.six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Ensure we only accept LTTextBoxes at the top level (not LTTextLines) ([#155](https://github.com/jstockwin/py-pdf-parser/pull/155))
 ## [0.6.0] - 2020-12-11
 ### Added
 - Enabled dependabot which should help to keep packages up to date ([#124](https://github.com/jstockwin/py-pdf-parser/pull/124))
 
-### Changes
+### Changed
 - Various dependency updates
 
 ### Fixed

--- a/py_pdf_parser/loaders.py
+++ b/py_pdf_parser/loaders.py
@@ -3,7 +3,7 @@ from typing import Dict, List, NamedTuple, IO, Optional
 import logging
 
 from pdfminer.high_level import extract_pages
-from pdfminer.layout import LTTextContainer, LAParams, LTFigure
+from pdfminer.layout import LTTextBox, LAParams, LTFigure
 
 from .components import PDFDocument
 
@@ -19,12 +19,12 @@ class Page(NamedTuple):
     Args:
         width (int): The width of the page.
         height (int): The height of the page.
-        elements (list): A list of PDF Miner elements (LTTextContainers) on the page.
+        elements (list): A list of PDF Miner elements (LTTextBox) on the page.
     """
 
     width: int
     height: int
-    elements: List[LTTextContainer]
+    elements: List[LTTextBox]
 
 
 def load_file(
@@ -71,16 +71,14 @@ def load(
 
     pages: Dict[int, Page] = {}
     for page in extract_pages(pdf_file, laparams=LAParams(**la_params)):
-        elements = [element for element in page if isinstance(element, LTTextContainer)]
+        elements = [element for element in page if isinstance(element, LTTextBox)]
 
         # If all_texts=True then we may get some text from inside figures
         if la_params.get("all_texts"):
             figures = (element for element in page if isinstance(element, LTFigure))
             for figure in figures:
                 elements += [
-                    element
-                    for element in figure
-                    if isinstance(element, LTTextContainer)
+                    element for element in figure if isinstance(element, LTTextBox)
                 ]
 
         if not elements:


### PR DESCRIPTION
**Description**

Ensures only `LTTextBoxes` get through as our `elements`. See #154 for details.

**Linked issues**

Closes #154

**Testing**

I have tested this on my broken pdf, and CI tests should still pass.

**Checklist**

- [x] I have provided a good description of the change above
- [x] I have added any necessary tests
- [x] I have added all necessary type hints
- [x] I have checked my linting (`docker-compose run --rm lint`)
- [x] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
