### PR TITLE
[github-actions] Update CI workflow to avoid login issues

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,14 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build the tests container using cache
-        uses: whoan/docker-build-with-cache-action@tag-image-as-a-separate-step
+      - name: Build the tests docker container
+        uses: docker/build-push-action@v2
         with:
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
-          image_name: jstockwin/py-pdf-parser-test
-          image_tag: test
-          dockerfile: dockerfiles/Dockerfile_tests
+          context: .
+          file: dockerfiles/Dockerfile_tests
+          tags: jstockwin/py-pdf-parser-test:test
       - name: Run linting
         run: docker run --rm jstockwin/py-pdf-parser-test:test .github/scripts/lint.sh
       - name: Run test


### PR DESCRIPTION
**Description**

Some PRs from other authors are failing CI due to not authenticating with the docker repo. This was needed as we used the "build with cache", which pushed and pulled partial images. I have now removed this.

**Linked issues**

None

**Testing**

CI will pass

**Checklist**

- [X] I have provided a good description of the change above
- [X] I have added any necessary tests
- [X] I have added all necessary type hints
- [X] I have checked my linting (`docker-compose run --rm lint`)
- [X] I have added/updated all necessary documentation
- [X] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
