### PR TITLE
[readthedocs] Bump python version from 3.6 to 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Changed python version from 3.6 to 3.8 in `.readthedocs.yml`.
 
 ## [0.9.0] - 2021-06-09
 ### Changed


### PR DESCRIPTION
**Description**

This upgrades the python version in the `.readthedocs.yml` file from Python 3.6 to 3.8. This is required as building the docs is currently failing because some of the requirements can't be installed in Python 3.6.

**Checklist**

- [x] I have provided a good description of the change above
- [ ] I have added any necessary tests
- [ ] I have added all necessary type hints
- [ ] I have checked my linting (`docker-compose run --rm lint`)
- [ ] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
