### PR TITLE
Update PDFMiners LAParams docs URL

### DIFF
--- a/py_pdf_parser/loaders.py
+++ b/py_pdf_parser/loaders.py
@@ -55,7 +55,7 @@ def load(
         pdf_file (io): The PDF file.
         la_params (dict): The layout parameters passed to PDF Miner for analysis. See
             the PDFMiner documentation here:
-            https://pdfminersix.readthedocs.io/en/latest/api/composable.html#laparams.
+            https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams.
             Note that py_pdf_parser will re-order the elements it receives from PDFMiner
             so options relating to element ordering will have no effect.
         pdf_file_path (str, optional): Passed to `PDFDocument`. See the documentation


### PR DESCRIPTION
**Description**

Fix broken URL (https://pdfminersix.readthedocs.io/en/latest/api/composable.html#laparams) to instead point to https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams

**Testing**

None

**Checklist**

- [X] I have provided a good description of the change above
- [X] I have added any necessary tests
- [X] I have added all necessary type hints
- [x] I have checked my linting (`docker-compose run --rm lint`)
- [X] I have added/updated all necessary documentation
- [ ] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
