### PR TITLE
[FIX] ElementList filter on visualise

### DIFF
--- a/py_pdf_parser/visualise/main.py
+++ b/py_pdf_parser/visualise/main.py
@@ -165,7 +165,7 @@ class PDFVisualiser:
             self.__ax.set_ylim([0, page.height])
 
         page = self.document.get_page(self.current_page)
-        for element in page.elements:
+        for element in page.elements and self.elements:
             style = STYLES["tagged"] if element.tags else STYLES["untagged"]
             self.__plot_element(element, style)
 


### PR DESCRIPTION
**Description**

When using a ElementList to filter Elements visualised by the visualise function, no filter is applied and all elements are displayed. The proposed changes, address this issue by performing the intersection between the pages' ElementList and the ElementList passed as argument. See #255 for details.

**Linked issues**
Closes #255

**Testing**

The changes were tested visually.
```python
from py_pdf_parser.loaders import load_file
from py_pdf_parser.visualise import visualise
document = load_file("path_to_file.pdf")
visualise(document, elements=document.elements[0::2]) #should only display every other element
```

**Checklist**

- [ ] I have provided a good description of the change above
- [ ] I have added any necessary tests
- [ ] I have added all necessary type hints
- [ ] I have checked my linting (`docker-compose run --rm lint`)
- [ ] I have added/updated all necessary documentation
- [ ] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
