### PR TITLE
Use pre-commit.ci for linting, add new linting checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,17 @@ repos:
     rev: 21.12b0
     hooks:
     -   id: black
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/mattseymour/pre-commit-pytype
+    rev: '2020.10.8'
+    hooks:
+    -   id: pytype
+        args: ['--disable=pyi-error,import-error']
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.931'
+    hooks:
+    -   id: mypy
+        args: [--install-types, --non-interactive]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,4 @@ repos:
     rev: 'v0.931'
     hooks:
     -   id: mypy
-        args: [--install-types, --non-interactive]
+        additional_dependencies: [types-mock]

--- a/py_pdf_parser/visualise/__init__.py
+++ b/py_pdf_parser/visualise/__init__.py
@@ -1,1 +1,5 @@
 from .main import visualise
+
+__all__ = [
+    "visualise",
+]

--- a/pytype.cfg
+++ b/pytype.cfg
@@ -1,0 +1,69 @@
+# NOTE: All relative paths are relative to the location of this file.
+
+[pytype]
+
+# Space-separated list of files or directories to exclude.
+exclude =
+    **/*_test.py
+    **/test_*.py
+
+# Space-separated list of files or directories to process.
+inputs =
+    .
+
+# Keep going past errors to analyze as many files as possible.
+keep_going = False
+
+# Run N jobs in parallel. When 'auto' is used, this will be equivalent to the
+# number of CPUs on the host system.
+jobs = 4
+
+# All pytype output goes here.
+output = .pytype
+
+# Paths to source code directories, separated by ':'.
+pythonpath =
+    .
+
+# Python version (major.minor) of the target code.
+python_version = 3.8
+
+# Use the enum overlay for more precise enum checking. This flag is temporary
+# and will be removed once this behavior is enabled by default.
+use_enum_overlay = Use the enum overlay for more precise enum checking.
+
+# Build dict literals from dict(k=v, ...) calls. This flag is temporary and will
+# be removed once this behavior is enabled by default.
+build_dict_literals_from_kwargs = Build dict literals from dict(k=v, ...) calls.
+
+# Enable stricter namedtuple checks, such as unpacking and 'typing.Tuple'
+# compatibility. This flag is temporary and will be removed once this behavior
+# is enabled by default.
+strict_namedtuple_checks = Enable stricter namedtuple checks, such as unpacking and 'typing.Tuple' compatibility.
+
+# Enable exhaustive checking of function parameter types. This flag is temporary
+# and will be removed once this behavior is enabled by default.
+strict_parameter_checks = Enable exhaustive checking of function parameter types.
+
+# Enable support for TypedDicts. This flag is temporary and will be removed once
+# this behavior is enabled by default.
+enable_typed_dicts = Enable support for TypedDicts.
+
+# Solve unknown types to label with structural types. This flag is temporary and
+# will be removed once this behavior is enabled by default.
+protocols = Solve unknown types to label with structural types.
+
+# Only load submodules that are explicitly imported. This flag is temporary and
+# will be removed once this behavior is enabled by default.
+strict_import = Only load submodules that are explicitly imported.
+
+# Infer precise return types even for invalid function calls. This flag is
+# temporary and will be removed once this behavior is enabled by default.
+precise_return = Infer precise return types even for invalid function calls.
+
+# Comma or space separated list of error names to ignore.
+disable =
+    pyi-error
+
+# Don't report errors.
+report_errors = True

--- a/tests/test_visualise.py
+++ b/tests/test_visualise.py
@@ -1,9 +1,4 @@
 import os
-import tkinter as tk
-import unittest
-
-import _tkinter
-from PIL import Image
 
 from py_pdf_parser.loaders import load_file
 from py_pdf_parser.visualise.main import PDFVisualiser


### PR DESCRIPTION
Follows on from https://github.com/jstockwin/py-pdf-parser/pull/288

Use pre-commit.ci for linting. This will run automatically as it's installed as github app.

The [first pre-commit.ci run](https://results.pre-commit.ci/run/github/218796970/1646757035.Yi-MApXjT1WbIPTc3zezwA) failed due to unused imports, which is good.

Required checks will need to be updated before merging, but I'll wait for @paulopaixaoamaral to approve first.