### PR TITLE
Ignore case for filter methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the ignore_case argument for `filter_by_text_equal` and `filter_by_text_contains` methods for the `ElementList` class in `filtering.py`
+
 ## [0.10.2] - 2022-11-07
 
 ### Changed

--- a/py_pdf_parser/filtering.py
+++ b/py_pdf_parser/filtering.py
@@ -133,7 +133,7 @@ class ElementList(Iterable):
         )
         return ElementList(self.document, new_indexes)
 
-    def filter_by_text_equal(self, text: str, stripped: bool = True) -> "ElementList":
+    def filter_by_text_equal(self, text: str, stripped: bool = True, ignore_case:bool = False) -> "ElementList":
         """
         Filter for elements whose text is exactly the given string.
 
@@ -141,27 +141,37 @@ class ElementList(Iterable):
             text (str): The text to filter for.
             stripped (bool, optional): Whether to strip the text of the element before
                 comparison. Default: True.
+            ignore_case (bool): Whether to ignore case sensitivity when filtering for matches. Default: False.
+            
 
         Returns:
             ElementList: The filtered list.
         """
-        new_indexes = set(
-            element._index for element in self if element.text(stripped) == text
-        )
+        if ignore_case:
+            new_indexes = set(
+                element._index for element in self if element.text(stripped).casefold() == text.casefold()
+            )
+        else:
+            new_indexes = set(
+                element._index for element in self if element.text(stripped) == text
+            )
 
         return ElementList(self.document, new_indexes)
 
-    def filter_by_text_contains(self, text: str) -> "ElementList":
+    def filter_by_text_contains(self, text: str, ignore_case:bool = False) -> "ElementList":
         """
         Filter for elements whose text contains the given string.
 
         Args:
             text (str): The text to filter for.
-
+            ignore_case (bool): Whether to ignore case sensitivity when filtering for matches. Default: False.
         Returns:
             ElementList: The filtered list.
         """
-        new_indexes = set(element._index for element in self if text in element.text())
+        if ignore_case:
+            new_indexes = set(element._index for element in self if text.casefold() in element.text().casefold())
+        else:
+            new_indexes = set(element._index for element in self if text in element.text())
         return ElementList(self.document, new_indexes)
 
     def filter_by_regex(


### PR DESCRIPTION
**Description**

Added the ability to ignore case sensitivity when filtering PDF elements by text matching. Default is not to ignore (i.e. doesn't break logic with previous versions).

**Linked issues**

closes https://github.com/jstockwin/py-pdf-parser/issues/371

**Testing**

Created a simple PDF with various uppercase-lowercase combinations. Compared length of filtered output when the associated `filter_by_text_equal` and `filter_by_text_contains` functions are run with `ignore_case` as both `True` and `False`. Behaves as expected.

Testing text:
![image](https://github.com/jstockwin/py-pdf-parser/assets/90392744/d3470d13-00bd-46ae-b7ed-53c5a088e90e)

Results:
![image](https://github.com/jstockwin/py-pdf-parser/assets/90392744/b0a4976c-9dda-49ae-ba06-3b8444c0e208)


**Checklist**

- [ ] I have provided a good description of the change above
- [ ] I have added any necessary tests
- [ ] I have added all necessary type hints
- [ ] I have checked my linting (`docker-compose run --rm lint`)
- [ ] I have added/updated all necessary documentation
- [ ] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
