### PR TITLE
standardized filter names for text_contains and text_equals

### DIFF
--- a/py_pdf_parser/filtering.py
+++ b/py_pdf_parser/filtering.py
@@ -132,14 +132,14 @@ class ElementList(Iterable):
             if any(tag in element.tags for tag in tags)
         )
         return ElementList(self.document, new_indexes)
-        
+
     def filter_by_text_equal(self, text: str, stripped: bool = True) -> "ElementList":
         """
         Backward compatibility. Simply calls filter_by_text_equals() with the same arguments.
         """
-        
+
         return self.filter_by_text_equals(text, stripped)
-    
+
     def filter_by_text_equals(self, text: str, stripped: bool = True) -> "ElementList":
         """
         Filter for elements whose text is exactly the given string.

--- a/py_pdf_parser/filtering.py
+++ b/py_pdf_parser/filtering.py
@@ -133,7 +133,7 @@ class ElementList(Iterable):
         )
         return ElementList(self.document, new_indexes)
 
-    def filter_by_text_equal(self, text: str, stripped: bool = True) -> "ElementList":
+    def filter_by_text_equals(self, text: str, stripped: bool = True) -> "ElementList":
         """
         Filter for elements whose text is exactly the given string.
 

--- a/py_pdf_parser/filtering.py
+++ b/py_pdf_parser/filtering.py
@@ -132,7 +132,14 @@ class ElementList(Iterable):
             if any(tag in element.tags for tag in tags)
         )
         return ElementList(self.document, new_indexes)
-
+        
+    def filter_by_text_equal(self, text: str, stripped: bool = True) -> "ElementList":
+        """
+        Backward compatibility. Simply calls filter_by_text_equals() with the same arguments.
+        """
+        
+        return self.filter_by_text_equals(text, stripped)
+    
     def filter_by_text_equals(self, text: str, stripped: bool = True) -> "ElementList":
         """
         Filter for elements whose text is exactly the given string.


### PR DESCRIPTION
The filters will now be called
`filter_by_text_contains()`
and
`filter_by_text_equals()`
with the added "s".