### PR TITLE
Remove tests and docs from wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added extra filtering methods for ElementList
+- Make sure tests and docs are not included in binary distribution wheels (PyPi) and source distribution (sdist).
 
 ## [0.12.0] - 2023-11-10
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 include README.md
 include LICENSE
+prune tests
+prune tests/*
+prune docs
+prune docs/*

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ ROOT_DIR = os.path.dirname(__file__)
 
 setup(
     name="py-pdf-parser",
-    packages=find_packages(),
-    exclude=["tests.*", "tests", "docs", "docs.*"],
+    packages=find_packages(exclude=["tests", "tests.*", "docs", "docs.*"]),
     version="0.12.0",
     url="https://github.com/jstockwin/py-pdf-parser",
     license="BSD",


### PR DESCRIPTION
**Description**

This change will remove tests and docs from binary distribution wheels (PyPi) and source distribution (sdist).

**Linked issues**

closes https://github.com/jstockwin/py-pdf-parser/issues/383

**Testing**

Run `python setup.py bdist_wheel` and confirm the tests directory is excluded from the generated wheel.

**Checklist**

- [x] I have provided a good description of the change above
- [x] I have added any necessary tests
- [x] I have added all necessary type hints
- [x] I have checked my linting (`docker-compose run --rm lint`)
- [x] I have added/updated all necessary documentation
- [x] I have updated `CHANGELOG.md`, following the format from
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
